### PR TITLE
MAINT: optimize.linprog: simplify bound checks when integrality > 1

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -640,7 +640,8 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
                              **solver_options)
         sol['status'], sol['message'] = (
             _check_result(sol['x'], sol['fun'], sol['status'], sol['slack'],
-                          sol['con'], lp.bounds, tol, sol['message'], integrality))
+                          sol['con'], lp.bounds, tol, sol['message'],
+                          integrality))
         sol['success'] = sol['status'] == 0
         return OptimizeResult(sol)
 
@@ -692,7 +693,8 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
 
     x, fun, slack, con = _postsolve(x, postsolve_args, complete)
 
-    status, message = _check_result(x, fun, status, slack, con, lp_o.bounds, tol, message, integrality)
+    status, message = _check_result(x, fun, status, slack, con, lp_o.bounds,
+                                    tol, message, integrality)
 
     if disp:
         _display_summary(message, status, fun, iteration)

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -2366,36 +2366,18 @@ class TestLinprogHiGHSMIP():
         assert not np.all(gap_diffs == 0)
 
     def test_semi_continuous(self):
-        # See issue #18106. This test if the integrality parameter
-        # is being checked correctly (status returns 0),
-        # when its > 1 it allows values to be 0 even if its out of bounds.
+        # See issue #18106. This tests whether the solution is being
+        # checked correctly (status is 0) when integrality > 1:
+        # values are allowed to be 0 even if 0 is out of bounds.
 
-        c = np.array([-1.])
-        A_ub = np.array([[1.]])
-        b_ub = np.array([0.5])
-        A_eq = np.zeros((0, 1), dtype=float)
-        b_eq = np.array([], dtype=float)
-        bounds = np.array([[1., 5.]])
-        integrality = np.array([2])
+        c = np.array([1., 1., -1, -1])
+        bounds = np.array([[0.5, 1.5], [0.5, 1.5], [0.5, 1.5], [0.5, 1.5]])
+        integrality = np.array([2, 3, 2, 3])
 
-        res = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
+        res = linprog(c, bounds=bounds,
                       integrality=integrality, method='highs')
 
-        assert np.all(res.x == 0)
-        assert res.status == 0
-
-        c = np.array([-1., -1., 1])
-        A_ub = np.array([[1., 1., 0], [1.,1., 0], [0,0,1]])
-        b_ub = np.array([0.5, 0.5, 1.])
-        A_eq = np.zeros((0, 3), dtype=float)
-        b_eq = np.array([], dtype=float)
-        bounds = np.array([[1., 5.], [1., 5.],  [0.5, 5]])
-        integrality = np.array([2, 2, 0])
-
-        res = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
-                      integrality=integrality, method='highs')
-
-        np.testing.assert_allclose(res.x, [0, 0, 0.5])
+        np.testing.assert_allclose(res.x, [0, 0, 1.5, 1])
         assert res.status == 0
 
 


### PR DESCRIPTION
#### Reference issue
scipy/scipy#18160

#### What does this implement/fix?
Hi @GonVas; SciPy maintainer here.
Thanks for your PR scipy/scipy#18160. It looks good, but I'd like to suggest a few simplifications. Comments supporting the changes are inline. Let me know what you think.